### PR TITLE
Changed the image pointed by docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     - 27017:27017
     command: --smallfiles
   app:
-    image: fede/demo-restapi
+    image: famigone/federepo:fede01
     ports:
     - 8080:8080
     links:


### PR DESCRIPTION
The pointer to the image fede/demo-restapi was changed to famigone/federepo:fede01 to conciliate with project documentation. assign @famigone 